### PR TITLE
Library for an iterable append only set

### DIFF
--- a/contracts/libraries/IterableAppendOnlySet.sol
+++ b/contracts/libraries/IterableAppendOnlySet.sol
@@ -1,0 +1,34 @@
+pragma solidity ^0.5.0;
+
+library IterableAppendOnlySet {
+    struct Data {
+        mapping(address => address) nextMap;
+        address last;
+    }
+
+    function insert(Data storage self, address value) public returns (bool) {
+        if (contains(self, value)) {
+            return false;
+        }
+        self.nextMap[self.last] = value;
+        self.last = value;
+        return true;
+    }
+
+    function contains(Data storage self, address value) public view returns (bool) {
+        require(value != address(0), "Inserting address(0) is not supported");
+        return self.nextMap[value] != address(0) || (self.last == value);
+    
+    }
+
+    function first(Data storage self) public view returns (address) {
+        require(self.last != address(0), "Trying to get first from empty set");
+        return self.nextMap[address(0)];
+    }
+
+    function next(Data storage self, address value) public view returns (address) {
+        require(contains(self, value), "Trying to get next of non-existent element");
+        require(value != self.last, "Trying to get next of last element");
+        return self.nextMap[value];
+    }
+}

--- a/contracts/libraries/wrappers/IterableAppendOnlySetWrapper.sol
+++ b/contracts/libraries/wrappers/IterableAppendOnlySetWrapper.sol
@@ -1,0 +1,28 @@
+pragma solidity ^0.5.0;
+
+import "../IterableAppendOnlySet.sol";
+
+contract IterableAppendOnlySetWrapper {
+    IterableAppendOnlySet.Data private data;
+    using IterableAppendOnlySet for IterableAppendOnlySet.Data;
+
+    function insert(address value) public returns (bool) {
+        return data.insert(value);
+    }
+
+    function contains(address value) public view returns (bool) {
+        return data.contains(value);
+    }
+
+    function first() public view returns (address) {
+        return data.first();
+    }
+    
+    function last() public view returns (address) {
+        return data.last;
+    }
+
+    function next(address value) public view returns (address) {
+        return data.next(value);
+    }
+}

--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -1,5 +1,10 @@
 const Migrations = artifacts.require("Migrations");
 
-module.exports = function(deployer) {
+const IterableSetLib = artifacts.require(".libraries/IterableAppendOnlySet.sol");
+const IterableSet = artifacts.require(".libraries/wrappers/IterableAppendOnlySetWrapper.sol");
+
+module.exports = async function (deployer) {
   deployer.deploy(Migrations);
+
+  await deployer.deploy(IterableSetLib);
 };

--- a/test/libraries/iterable_append_only_set.js
+++ b/test/libraries/iterable_append_only_set.js
@@ -1,0 +1,102 @@
+const IterableSetLib = artifacts.require(".libraries/IterableAppendOnlySet.sol");
+const IterableSet = artifacts.require(".libraries/wrappers/IterableAppendOnlySetWrapper.sol");
+
+const truffleAssert = require("truffle-assertions")
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+async function getSetContent(set) {
+  const last = await set.last()
+  const result = []
+  if (last != ZERO_ADDRESS) {
+    let current = await set.first()
+    result.push(current)
+    while (current != last) {
+      current = await set.next(current);
+      result.push(current)
+    }
+  }
+  return result
+}
+
+contract('IterableSet', function (accounts) {
+  beforeEach(async () => {
+    const lib = await IterableSetLib.new()
+    await IterableSet.link(IterableSetLib, lib.address)
+  })
+
+  it("should contain the added values", async () => {
+    const set = await IterableSet.new()
+    assert.deepEqual(await getSetContent(set), [])
+
+    assert.equal(await set.contains(accounts[0]), false, "The element should not be there")
+    await set.insert(accounts[0])
+
+    assert.equal(await set.contains(accounts[0]), true, "The element should be there")
+    assert.deepEqual(await getSetContent(set), accounts.slice(0, 1))
+  });
+
+  it("should insert the same value only once", async () => {
+    const set = await IterableSet.new()
+
+    assert.equal(await set.insert.call(accounts[0]), true, "First insert should insert")
+    await set.insert(accounts[0])
+    assert.deepEqual(await getSetContent(set), accounts.slice(0, 1))
+
+    assert.equal(await set.insert.call(accounts[0]), false, "Second insert should do nothing")
+    await set.insert(accounts[0])
+    assert.deepEqual(await getSetContent(set), accounts.slice(0, 1))
+  });
+
+  it("should return first and last element", async () => {
+    const set = await IterableSet.new()
+
+    await set.insert(accounts[0])
+    assert.equal(await set.first(), accounts[0])
+    assert.equal(await set.last(), accounts[0])
+
+    await set.insert(accounts[1])
+    assert.equal(await set.first(), accounts[0])
+    assert.equal(await set.last(), accounts[1])
+  })
+
+  it("should allow to iterate over content", async () => {
+    const set = await IterableSet.new()
+
+    await set.insert(accounts[0])
+    await set.insert(accounts[1])
+    await set.insert(accounts[2])
+
+    const first = await set.first()
+    const second = await set.next(first)
+    const third = await set.next(second)
+
+    assert.equal(first, accounts[0])
+    assert.equal(second, accounts[1])
+    assert.equal(third, accounts[2])
+  })
+
+  it("doesn't allow to insert 0 address", async () => {
+    const set = await IterableSet.new()
+    await truffleAssert.reverts(set.insert(ZERO_ADDRESS))
+  })
+
+  it("cannot get first of empty list", async () => {
+    const set = await IterableSet.new()
+    await truffleAssert.reverts(set.first())
+  })
+
+  it("cannot get next of non-existent element", async () => {
+    const set = await IterableSet.new()
+
+    await set.insert(accounts[0])
+    await truffleAssert.reverts(set.next(accounts[1]))
+  })
+
+  it("cannot get next of last element", async () => {
+    const set = await IterableSet.new()
+
+    await set.insert(accounts[0])
+    await truffleAssert.reverts(set.next(accounts[0]))
+  })
+});


### PR DESCRIPTION
This PR implements an iterable append only set library that can store addresses. This will be used e.g. here: https://github.com/gnosis/dex-contracts/pull/177

It's arguable whether this is something generic enough to live in its own repo, so looking forward to what you guys think. Happy to move it into the dƒusion repo, if you think it's not worth collecting general purpose data structures in a common repo.

### Test Plan

100% unit test branch coverage.