### PR TITLE
[IterableAppendOnlySet] add size function

### DIFF
--- a/contracts/libraries/IterableAppendOnlySet.sol
+++ b/contracts/libraries/IterableAppendOnlySet.sol
@@ -31,4 +31,17 @@ library IterableAppendOnlySet {
         require(value != self.last, "Trying to get next of last element");
         return self.nextMap[value];
     }
+
+    function size(Data storage self) public view returns (uint256) {
+        if (self.last == address(0)) {
+            return 0;
+        }
+        uint256 count = 1;
+        address current = first(self);
+        while(current != self.last) {
+            current = next(self, current);
+            count ++;
+        }
+        return count;
+    }
 }

--- a/contracts/libraries/IterableAppendOnlySet.sol
+++ b/contracts/libraries/IterableAppendOnlySet.sol
@@ -38,9 +38,9 @@ library IterableAppendOnlySet {
         }
         uint256 count = 1;
         address current = first(self);
-        while(current != self.last) {
+        while (current != self.last) {
             current = next(self, current);
-            count ++;
+            count++;
         }
         return count;
     }

--- a/contracts/libraries/wrappers/IterableAppendOnlySetWrapper.sol
+++ b/contracts/libraries/wrappers/IterableAppendOnlySetWrapper.sol
@@ -23,6 +23,10 @@ contract IterableAppendOnlySetWrapper {
         return data.last;
     }
 
+    function size() public view returns (uint256) {
+        return data.size();
+    }
+
     function next(address value) public view returns (address) {
         return data.next(value);
     }

--- a/test/libraries/iterable_append_only_set.js
+++ b/test/libraries/iterable_append_only_set.js
@@ -36,6 +36,21 @@ contract("IterableSet", function (accounts) {
     assert.deepEqual(await getSetContent(set), accounts.slice(0, 1))
   })
 
+  it("should keep track of the size", async () => {
+    const set = await IterableSet.new()
+    assert.equal((await set.size()).toNumber(), 0)
+
+    await set.insert(accounts[0])
+    assert.equal((await set.size()).toNumber(), 1)
+
+    await set.insert(accounts[1])
+    assert.equal((await set.size()).toNumber(), 2)
+
+    // re-add already existing address[0]
+    await set.insert(accounts[0])
+    assert.equal((await set.size()).toNumber(), 2)
+  })
+
   it("should insert the same value only once", async () => {
     const set = await IterableSet.new()
 


### PR DESCRIPTION
We need to know the size of the set when trying to convert it into a list (e.g. to pass it to the caller of our smart contract), since memory arrays need to have a known size (variable sized arrays only work in storage).

This PR adds a view function for the size, which doesn't require any additional cost on insertion. We could alternatively store the size on the data but this would cost an sstore and every addition. Since this method is designed to be called in view functions only, we don't care about potentially running the for loop twice (once to get the count and then again to get the elements)


### Test Plan

Unit tests
