### PR TITLE
Append Only Set: include view to get elements by index

### DIFF
--- a/contracts/libraries/IterableAppendOnlySet.sol
+++ b/contracts/libraries/IterableAppendOnlySet.sol
@@ -44,4 +44,13 @@ library IterableAppendOnlySet {
         }
         return count;
     }
+
+    function atIndex(Data storage self, uint256 index) public view returns (address) {
+        require(index < size(self), "requested index too large");
+        address res = first(self);
+        for (uint256 i = 0; i < index; i++) {
+            res = next(self, res);
+        }
+        return res;
+    }
 }

--- a/contracts/libraries/wrappers/IterableAppendOnlySetWrapper.sol
+++ b/contracts/libraries/wrappers/IterableAppendOnlySetWrapper.sol
@@ -30,4 +30,8 @@ contract IterableAppendOnlySetWrapper {
     function next(address value) public view returns (address) {
         return data.next(value);
     }
+
+    function atIndex(uint256 index) public view returns (address) {
+        return data.atIndex(index);
+    }
 }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "@gnosis.pm/util-contracts": "^2.0.2",
     "ethereumjs-util": "^6.1.0",
-    "merkletreejs": "0.0.22",
-    "truffle": "^5.0.34"
+    "merkletreejs": "0.0.22"
   },
   "devDependencies": {
     "coveralls": "^3.0.4",

--- a/test/libraries/iterable_append_only_set.js
+++ b/test/libraries/iterable_append_only_set.js
@@ -114,4 +114,25 @@ contract("IterableSet", function (accounts) {
     await set.insert(accounts[0])
     await truffleAssert.reverts(set.next(accounts[0]))
   })
+
+  it("fetches elements at index (by insertion order)", async () => {
+    const set = await IterableSet.new()
+
+    await set.insert(accounts[0])
+    await set.insert(accounts[1])
+
+    assert.equal(await set.atIndex(0), accounts[0])
+    assert.equal(await set.atIndex(1), accounts[1])
+  })
+  it("fails to fetches at index when requested index is too large", async () => {
+    const set = await IterableSet.new()
+
+    // Nothing in the set yet!
+    await truffleAssert.reverts(set.atIndex(0))
+
+    await set.insert(accounts[0])
+    await truffleAssert.reverts(set.atIndex(1))
+  })
+
+
 })


### PR DESCRIPTION
In some scenarios (cf. https://github.com/gnosis/dex-contracts/issues/269) it can be beneficial to expose a retrieval function for set element search based on order of inclusion (i.e. index). Since our set is iterable, it has a root element and thus, elements in this linked list have an index.

Now, any contract using such a library can expose a `public view`which might look as follows:

```py
    function accountIdToAddressMap(uint16 id) public view returns (address) {
        return allUsers.atIndex(id);
    }
```

**TestPlan:** `truffle test`