### PR TITLE
[BiMap] No insert zero address or max uint16

### DIFF
--- a/contracts/libraries/IdToAddressBiMap.sol
+++ b/contracts/libraries/IdToAddressBiMap.sol
@@ -26,6 +26,8 @@ library IdToAddressBiMap {
     }
 
     function insert(Data storage self, uint16 id, address addr) public returns (bool) {
+        require(addr != address(0), "Cannot insert zero address");
+        require(id != uint16(-1), "Cannot insert max uint16");
         // Ensure bijectivity of the mappings
         if (self.addressToId[addr] != 0 || self.idToAddress[id + 1] != address(0)) {
             return false;

--- a/test/libraries/bimap.js
+++ b/test/libraries/bimap.js
@@ -4,12 +4,11 @@ const IdToAddressBiMap = artifacts.require("IdToAddressBiMap")
 const truffleAssert = require("truffle-assertions")
 
 
-
 contract("BiMap", async (accounts) => {
 
   describe("All BiMap Functions", () => {
     
-    it("bijectivity properties", async () => {
+    it("admits bijectivity properties", async () => {
       const lib = await IdToAddressBiMap.new()
       await IdToAddressBiMapWrapper.link(IdToAddressBiMap, lib.address)
       const map = await IdToAddressBiMapWrapper.new()
@@ -36,6 +35,26 @@ contract("BiMap", async (accounts) => {
       // Don't allow insert if either id or address is already part of the map.
       assert.equal(false, await map.insert.call(1, accounts[0]))
       assert.equal(false, await map.insert.call(0, accounts[1]))
+    })
+    it("does not allow insertion of address(0)", async () => {
+      const lib = await IdToAddressBiMap.new()
+      await IdToAddressBiMapWrapper.link(IdToAddressBiMap, lib.address)
+      const map = await IdToAddressBiMapWrapper.new()
+
+      await truffleAssert.reverts(
+        map.insert(42, "0x0000000000000000000000000000000000000000"),
+        "Cannot insert zero address"
+      )
+    })
+    it("does not allow insertion of max uint16", async () => {
+      const lib = await IdToAddressBiMap.new()
+      await IdToAddressBiMapWrapper.link(IdToAddressBiMap, lib.address)
+      const map = await IdToAddressBiMapWrapper.new()
+
+      await truffleAssert.reverts(
+        map.insert(2 ** 16 - 1, accounts[0]),
+        "Cannot insert max uint16"
+      )
     })
   })
 })


### PR DESCRIPTION
Include two new require statements disallowing insertion of zero address and max uint16 along with supporting unit tests. If only there was a nicer way to access `address(0)` from web3... So many stack exchange answers all pointing at just using "0x00...000".