### PR TITLE
version bump v1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/solidity-data-structures",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/solidity-data-structures",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A collection of basic data structures implemented in solidity",
   "main": "truffle-config.js",
   "directories": {


### PR DESCRIPTION
I could not unpublish v1.2.2. Hence, I am publishing a new version for the deployed contracts:
```
➜  solidity-data-structures git:(master) npm unpublish @gnosis.pm/solidity-data-structures@1.2.2 
npm ERR! unpublish Failed to update data
npm ERR! code E400
npm ERR! You can no longer unpublish this version. Please deprecate it instead
npm ERR! npm deprecate @gnosis.pm/solidity-data-structures@1.2.2 "this version has been deprecated" : 7-33e516019dbde42470d56eba3ac5ab17

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/alexherrmann/.npm/_logs/2020-01-22T21_30_29_256Z-debug.log
```