### PR TITLE
Version bump to 1.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/solidity-data-structures",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A collection of basic data structures implemented in solidity",
   "main": "truffle-config.js",
   "directories": {


### PR DESCRIPTION
I am very sorry about another version bump.
I published 1.2.3 and then unpublished it immediately again, as I wanted to make sure that it really had the right deployment addresses. 
But I was not aware that I can not overwrite an unpublished package. :(
